### PR TITLE
refactor: common asset processor

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -36,6 +36,7 @@ EMSCH_ENVS='{"template": {"regex": "/^template.*/", "index": "template", "backen
 EMSCH_TRANSLATION_TYPE=label
 EMSCH_REDIRECT_TYPE=redirect
 EMSCH_ROUTE_TYPE=route
+#EMSCH_ASSET_CONFIG_TYPE=asset_config
 #EMSCH_ROUTES='{"my_route": {"type": "my_content_type", "path": "/{_locale}/{slug}", "query": "{\"query\": {\"term\": {\"slug_%_locale%\": \"%slug%\"}}}", "requirements": {"_locale": "fr|nl"}, "template": "@EMSCH/template/my_content_type.html.twig"}}'
 
 EMSCH_SEARCH_TYPES='["url"]'

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,6 @@
         "symfony/asset": "^4.1",
         "symfony/console": "^4.1",
         "symfony/expression-language": "^4.1",
-        "symfony/flex": "^1.0",
         "symfony/form": "^4.1",
         "symfony/framework-bundle": "^4.1",
         "symfony/monolog-bundle": "^3.1",
@@ -23,7 +22,8 @@
         "symfony/validator": "^4.1",
         "symfony/web-link": "^4.1",
         "symfony/webpack-encore-pack": "*",
-        "symfony/yaml": "^4.1"
+        "symfony/yaml": "^4.1",
+        "ext-gd": "*"
     },
     "require-dev": {
         "symfony/debug-pack": "*",

--- a/config/packages/ems_client_helper.yaml
+++ b/config/packages/ems_client_helper.yaml
@@ -7,6 +7,7 @@ parameters:
 
     env(EMSCH_ROUTE_TYPE):       ~
     env(EMSCH_TRANSLATION_TYPE): label
+    env(EMSCH_ASSET_CONFIG_TYPE): ~
     env(EMSCH_TEMPLATES): '{}'
     env(EMSCH_ROUTES): '{}'
 
@@ -33,6 +34,7 @@ ems_client_helper:
             index_prefix: '%env(string:EMSCH_INSTANCE_ID)%'
             route_type: '%env(string:EMSCH_ROUTE_TYPE)%'
             translation_type: '%env(string:EMSCH_TRANSLATION_TYPE)%'
+            asset_config_type: '%env(string:EMSCH_ASSET_CONFIG_TYPE)%'
             templates: '%env(json:EMSCH_TEMPLATES)%'
             search:
                 types:         '%env(json:EMSCH_SEARCH_TYPES)%'

--- a/config/packages/ems_common.yaml
+++ b/config/packages/ems_common.yaml
@@ -1,2 +1,0 @@
-ems_common:
-    storage: true

--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -1,2 +1,5 @@
 files:
     resource: '@EMSCommonBundle/Resources/config/routing/file.xml'
+
+helper:
+    resource: '@EMSClientHelperBundle/Resources/config/routing/helper.xml'

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -8,6 +8,13 @@ services:
         autoconfigure: true
         public: false
 
-    EMS\CommonBundle\Storage\Adapter\FileAdapter:
-        arguments: ['%env(STORAGE_PATH)%']
-        tags: [ems_common.storage.adapter]
+    app.ems.cache:
+        class: EMS\CommonBundle\Storage\Adapter\FileAdapter
+        arguments: ['%env(string:STORAGE_PATH)%/cache']
+        tags:
+            - { name: ems_common.storage.cache_adapter }
+    app.ems.filesystem:
+        class: EMS\CommonBundle\Storage\Adapter\FileAdapter
+        arguments: ['%env(string:STORAGE_PATH)%']
+        tags:
+            - { name: ems_common.storage.adapter }


### PR DESCRIPTION
Moved image/asset processor logic from core to common bundle.
The core and the skeleton will use the common processor in their controllers.

- remove flex composer requirement
- add ext-gd composer requirement
- remove ems_common config (no config needed)
- add 2 storage adapters (filesystem, cache)

Other pull requests:
- https://github.com/ems-project/elasticms/pull/16
- https://github.com/ems-project/EMSClientHelperBundle/pull/84
- https://github.com/ems-project/EMSCoreBundle/pull/94
- https://github.com/ems-project/EMSCommonBundle/pull/7